### PR TITLE
feat: allow providing `fields` as input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ inputs:
     description: "Path for field mapping configuration"
     default: ".github/jira-config.yml"
     required: false
+  fields:
+    description: "Fields for resolve-issue action"
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/jira.js
+++ b/src/jira.js
@@ -70,6 +70,11 @@ exports.resolveIssue = async function (issue) {
   }
   if (context.payload.client_payload && context.payload.client_payload.fields) {
     Object.assign(fields, context.payload.client_payload.fields);
+  } else {
+    const inputFields = core.getInput("fields");
+    if (inputFields) {
+      Object.assign(fields, JSON.parse(inputFields));
+    }
   }
   const resolve = { transition, fields };
   console.log(`Update issue:\n${JSON.stringify(resolve)}`);


### PR DESCRIPTION
Usage:

```
  - name: Update ticket status
    uses: elisa-actions/jira-issue@v1
    with:
      fields: {"customfield_10916": {"id": "${{ steps.deployment_results.outputs.closure_code }}"}}'
      action: "resolve-issue"
```